### PR TITLE
Support nested paths for shapes  a

### DIFF
--- a/lib/shapeable/shape.rb
+++ b/lib/shapeable/shape.rb
@@ -61,7 +61,7 @@ module Shapeable
     end
 
     def infer_resource_name(path)
-      path.name.split('::').last.constantize
+      path.name.split('::').last
     end
   end
 end


### PR DESCRIPTION
By allowign the resource name inference to return a string rather than a constant. It's used in string interpolation and doesn't need to be a constant